### PR TITLE
Correcting status codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "udacity-c2-image-filter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,12 +33,12 @@ import { filterImageFromURL, deleteLocalFiles, validateImage } from './util/util
 
         if (err) {
           console.error(`Error sending file: ${err}`);
-          res.send({ error: err }).status(500);
+          res.status(500).send({ error: err });
         }
       });
     } catch (exc) {
       console.error(`Exception filtering image: ${exc}`);
-      res.send({ error: `${exc}` }).status(500);
+      res.status(500).send({ error: `${exc}` });
     }
 
   });

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -41,11 +41,11 @@ export function validateImage(req: Request, res: Response, next: Function) {
   const { image_url: imageUrl }: { image_url: string } = req.query;
 
   if (!imageUrl) {
-    return res.json({ message: "Empty URL provided" }).status(400);
+    return res.status(400).json({ message: "Empty URL provided" });
   }
 
   if (!checkExtension(imageUrl)) {
-    return res.json({ message: "Invalid image extension provided. Accepted are [jpg|jpeg|png|bmp|tiff|gif]", }).status(422);
+    return res.status(422).json({ message: "Invalid image extension provided. Accepted are [jpg|jpeg|png|bmp|tiff|gif]", });
   }
 
   req.body.imageUrl = imageUrl;


### PR DESCRIPTION
Status code ordering corrected. 

Now returning correct codes:
- 200 is returned in case of success. 
- 400 when empty URL is provided
- 422 when an invalid extension is provided